### PR TITLE
Figure testing

### DIFF
--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1326,11 +1326,10 @@ def raw_report(report_objects, metrics):
     )
 
     def gen(with_series):
-
         def ser(interval_length):
             ser_index = pd.date_range(
                 report.start, report.end, freq=to_offset(interval_length),
-                name='timestamp', tz='UTC')
+                name='timestamp')
             ser_value = pd.Series(
                 np.repeat(100, len(ser_index)), name='value',
                 index=ser_index)

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1280,7 +1280,7 @@ def metric_index():
 
 
 @pytest.fixture
-def metrics(metric_index):
+def report_metrics(metric_index):
     """Produces dummy MetricResult list for a RawReport"""
     def gen(report):
         metrics = ()
@@ -1315,7 +1315,7 @@ def metrics(metric_index):
 
 
 @pytest.fixture()
-def raw_report(report_objects, metrics):
+def raw_report(report_objects, report_metrics):
     report, obs, fx0, fx1, agg, fxagg = report_objects
     meta = datamodel.ReportMetadata(
         name=report.name,
@@ -1368,7 +1368,7 @@ def raw_report(report_objects, metrics):
             forecast_values=ser(ilagg) if with_series else fxagg.forecast_id,
             observation_values=ser(ilagg) if with_series else agg.aggregate_id
         )
-        raw = datamodel.RawReport(meta, 'template', metrics(report),
+        raw = datamodel.RawReport(meta, 'template', report_metrics(report),
                                   (fxobs0, fxobs1, fxagg_))
         return raw
     return gen
@@ -1597,3 +1597,96 @@ def aggregate_prob_forecast(aggregate_prob_forecast_text,
         provider=fx_dict.get('provider', ''),
         axis=fx_dict['axis'],
         constant_values=(agg_prob_forecast_constant_value, ))
+
+
+@pytest.fixture
+def metric_value_dict():
+    return {
+        'category': 'total',
+        'metric': 'mae',
+        'index': 1,
+        'value': 1,
+    }
+
+
+@pytest.fixture
+def metric_value(metric_value_dict):
+    return datamodel.MetricValue.from_dict(metric_value_dict)
+
+
+@pytest.fixture
+def metric_result_dict(metric_value_dict):
+    return {
+        'name': 'total tucson ghi mae',
+        'forecast_id': 'fxid',
+        'values': [metric_value_dict],
+        'observation_id': 'obsid',
+        'aggregate_id': None,
+    }
+
+
+@pytest.fixture
+def metric_result(metric_result_dict):
+    return datamodel.MetricResult.from_dict(metric_result_dict)
+
+
+@pytest.fixture
+def validation_result_dict():
+    return {
+        'flag': 2,
+        'count': 1,
+    }
+
+
+@pytest.fixture
+def validation_result(validation_result_dict):
+    return datamodel.ValidationResult.from_dict(validation_result_dict)
+
+
+@pytest.fixture
+def report_metadata_dict():
+    return {
+        'name': 'Report 1',
+        'start': '2019-01-01T00:00Z',
+        'end': '2019-01-02T00:00Z',
+        'now': '2019-01-03T00:00Z',
+        'timezone': 'America/Pheonix',
+        'versions': {}
+    }
+
+
+@pytest.fixture
+def report_metadata(report_metadata_dict):
+    return datamodel.ReportMetadata.from_dict(report_metadata_dict)
+
+
+@pytest.fixture
+def report_figure_dict():
+    return {
+        'name': 'mae tucson ghi',
+        'div': '<div></div>',
+        'svg': '<svg></svg>',
+        'type': 'plot?',
+        'category': 'total',
+        'metric': 'mae'
+    }
+
+
+@pytest.fixture
+def report_figure(report_figure_dict):
+    return datamodel.ReportFigure.from_dict(report_figure_dict)
+
+
+@pytest.fixture
+def report_message_dict():
+    return {
+        'message': 'Report was bad',
+        'step': 'calculating metrics',
+        'level': 'exception',
+        'function': 'calculate_deterministic_metrics',
+    }
+
+
+@pytest.fixture
+def report_message(report_message_dict):
+    return datamodel.ReportMessage.from_dict(report_message_dict)

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1283,7 +1283,7 @@ def metric_index():
 def metrics(metric_index):
     """Produces dummy MetricResult list for a RawReport"""
     def gen(report):
-        metrics = []
+        metrics = ()
         for fxobs in report.forecast_observations:
             values = []
             if hasattr(fxobs, 'observation'):
@@ -1308,7 +1308,8 @@ def metrics(metric_index):
                     }
                 ))
             metrics_dict['values'] = values
-            metrics.append(datamodel.MetricResult.from_dict(metrics_dict))
+            metrics = metrics + (
+                datamodel.MetricResult.from_dict(metrics_dict),)
         return metrics
     return gen
 

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1368,7 +1368,20 @@ def raw_report(report_objects, report_metrics):
             forecast_values=ser(ilagg) if with_series else fxagg.forecast_id,
             observation_values=ser(ilagg) if with_series else agg.aggregate_id
         )
-        raw = datamodel.RawReport(meta, 'template', report_metrics(report),
+        figs = datamodel.RawReportPlots(
+            '1.4.0', '<script></script', (
+                datamodel.ReportFigure.from_dict(
+                    {
+                        'name': 'mae tucson ghi',
+                        'div': '<div></div>',
+                        'svg': '<svg></svg>',
+                        'type': 'plot?',
+                        'category': 'total',
+                        'metric': 'mae'
+                    }
+                ),)
+        )
+        raw = datamodel.RawReport(meta, figs, report_metrics(report),
                                   (fxobs0, fxobs1, fxagg_))
         return raw
     return gen
@@ -1445,6 +1458,20 @@ def aggregate_observations(aggregate_text, many_observations):
         observation_deleted_at=_tstamp(o['observation_deleted_at']))
         for o in aggd['observations']])
     return aggobs
+
+
+@pytest.fixture()
+def single_aggregate_observation_text(single_observation_text_with_site_text):
+    return (b'{"observation": ' + single_observation_text_with_site_text +
+            b', "effective_from": "2019-01-03T13:00:00Z"}')
+
+
+@pytest.fixture()
+def single_aggregate_observation(single_observation):
+    return datamodel.AggregateObservation(
+        observation=single_observation,
+        effective_from=pd.Timestamp('2019-01-03T13:00:00Z')
+    )
 
 
 @pytest.fixture()

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -516,15 +516,6 @@ class AggregateObservation(BaseModel):
     effective_until: Union[pd.Timestamp, None] = None
     observation_deleted_at: Union[pd.Timestamp, None] = None
 
-    def _special_field_processing(self, model_field, val):
-        if model_field.name in ('effective_until', 'observation_deleted_at'):
-            if val is None:
-                return val
-            else:
-                return pd.Timestamp(val)
-        else:  # pragma: no cover
-            return val
-
 
 def __check_variable__(variable, *args):
     if not all(arg.variable == variable for arg in args):
@@ -697,20 +688,6 @@ class Forecast(BaseModel, _ForecastDefaultsBase, _ForecastBase):
     def __post_init__(self):
         __set_units__(self)
         __site_or_agg__(self)
-
-    def _special_field_processing(self, model_field, val):
-        if model_field.name == 'site':
-            if isinstance(val, dict):
-                return Site.from_dict(val)
-            else:
-                return val
-        elif model_field.name == 'aggregate':
-            if isinstance(val, dict):
-                return Aggregate.from_dict(val)
-            else:
-                return val
-        else:
-            return val
 
 
 @dataclass(frozen=True)

--- a/solarforecastarbiter/reports/tests/test_figures.py
+++ b/solarforecastarbiter/reports/tests/test_figures.py
@@ -1,7 +1,204 @@
-from solarforecastarbiter.reports import figures
+from bokeh.models import ColumnDataSource
 
+import numpy as np
 
 import pytest
+
+
+from solarforecastarbiter.reports import figures
+from solarforecastarbiter import datamodel
+
+
+@pytest.fixture
+def report_with_raw(report_dict, raw_report):
+    report_dict['raw_report'] = raw_report(True)
+    report = datamodel.Report.from_dict(report_dict)
+    return report
+
+
+def test_construct_metrics_cds(report_with_raw):
+    report = report_with_raw
+    metrics = report.raw_report.metrics
+    cds = figures.construct_metrics_cds(metrics)
+    names = cds.data['name']
+    abbrev = cds.data['abbrev']
+    categories = cds.data['category']
+    metrics = cds.data['metric']
+    values = cds.data['value']
+
+    expected_length = (len(report.metrics) * len(report.categories) *
+                       len(report.forecast_observations))
+    assert all([len(v) == expected_length for k, v in cds.data.items()])
+
+    original_names = [fxobs.forecast.name
+                      for fxobs in report.forecast_observations]
+    assert np.all(
+        names == np.repeat(
+            np.array(original_names),
+            len(report.metrics) * len(report.categories))
+    )
+    assert np.all(names == abbrev)
+
+    assert np.all(
+        metrics == np.tile(
+            np.repeat(np.array(report.metrics, dtype=object),
+                      len(report.categories)),
+            len(report.forecast_observations))
+    )
+
+    assert np.all(
+        categories == np.tile(
+            np.array(report.categories),
+            len(report.metrics) * len(report.forecast_observations))
+    )
+
+    # this could maybe use value variance, but asserting the cds process
+    # did not mangle values for now
+    assert (values == 1).all()
+
+
+def test_construct_metrics_cds_with_rename(report_with_raw):
+    metrics = report_with_raw.raw_report.metrics
+    cds = figures.construct_metrics_cds(metrics,
+                                        rename=figures.abbreviate)
+    original_names = [fxobs.forecast.name
+                      for fxobs in report_with_raw.forecast_observations]
+    abbreviated = list(map(figures.abbreviate, original_names))
+    assert np.all(
+        cds.data['abbrev'] == np.repeat(
+            np.array(abbreviated, dtype=object),
+            len(report_with_raw.metrics) * len(report_with_raw.categories))
+    )
+
+
+def test_construct_timeseries_cds(report_with_raw):
+    report = report_with_raw
+    raw_report = report.raw_report
+    timeseries_cds, metadata_cds = figures.construct_timeseries_cds(report)
+
+    ts_pair_index = timeseries_cds.data['pair_index']
+    assert np.all(
+        ts_pair_index == np.arange(len(report.forecast_observations)).repeat(
+            [len(fxob.forecast_values)
+             for fxob in raw_report.processed_forecasts_observations])
+    )
+    observation_values = timeseries_cds.data['observation_values']
+    forecast_values = timeseries_cds.data['forecast_values']
+    assert len(observation_values) == len(ts_pair_index)
+    assert len(forecast_values) == len(ts_pair_index)
+    # just testing for non-mangling behavior here
+    assert np.all(observation_values == 100)
+    assert np.all(forecast_values == 100)
+
+    assert 'pair_index' in metadata_cds.data
+    assert 'observation_name' in metadata_cds.data
+    assert 'forecast_name' in metadata_cds.data
+    assert 'interval_label' in metadata_cds.data
+    assert 'observation_hash' in metadata_cds.data
+    assert 'forecast_hash' in metadata_cds.data
+    assert 'observation_color' in metadata_cds.data
+
+
+@pytest.mark.parametrize('hash_key', [
+    'observation_hash', 'forecast_hash'])
+def test_extract_metadata_from_cds(report_with_raw, hash_key):
+    timeseries_cds, metadata_cds = figures.construct_timeseries_cds(
+        report_with_raw)
+    for the_hash in metadata_cds.data[hash_key]:
+        metadata = figures._extract_metadata_from_cds(
+            metadata_cds, the_hash, hash_key)
+        assert 'pair_index' in metadata
+        assert 'observation_name' in metadata
+        assert 'interval_label' in metadata
+        assert 'observation_color' in metadata
+
+
+@pytest.fixture
+def fxobs_name_mock(mocker):
+    def fn(obs_name, fx_name, agg=False):
+        if agg:
+            obspec = datamodel.Aggregate
+        else:
+            obspec = datamodel.Observation
+        fxobs = mocker.Mock()
+        obs = mocker.Mock(spec=obspec)
+        obs.name = obs_name
+        fx = mocker.Mock()
+        fx.name = fx_name
+        fxobs.forecast = fx
+        fxobs.data_object = obs
+        return fxobs
+    return fn
+
+
+def test_obs_name_same(fxobs_name_mock):
+    name = 'ghi 1 hr'
+    fxobs = fxobs_name_mock(name, name)
+    fxagg = fxobs_name_mock(name, name, True)
+    new_obsname = figures._obs_name(fxobs)
+    new_aggname = figures._obs_name(fxagg)
+    assert new_obsname == f'{name} Observation'
+    assert new_aggname == f'{name} Aggregate'
+
+
+def test_obs_name_same_diff(fxobs_name_mock):
+    name = 'ghi 1 hr'
+    fx_name = 'ghi 1 hr fx'
+    fxobs = fxobs_name_mock(name, fx_name)
+    fxagg = fxobs_name_mock(name, fx_name, True)
+    new_obsname = figures._obs_name(fxobs)
+    new_aggname = figures._obs_name(fxagg)
+    assert new_obsname == name
+    assert new_aggname == name
+
+
+def test_fx_name_same(fxobs_name_mock):
+    fxobs = fxobs_name_mock('same', 'same')
+    new_fx_name = figures._fx_name(fxobs)
+    assert new_fx_name == 'same Forecast'
+
+
+def test_fx_name_diff(fxobs_name_mock):
+    fxobs = fxobs_name_mock('same', 'diff')
+    new_fx_name = figures._fx_name(fxobs)
+    assert new_fx_name == 'diff'
+
+
+@pytest.mark.parametrize('array,index,expected', [
+    ([1, 2, 3, 4], 2, [False, True, False, False]),
+    ([1, 1, 3, 4], 2, [False, False, False, False]),
+    ([1, 1, 1, 1], 1, [True, True, True, True]),
+])
+def test_boolean_filter_indices_by_pair(mocker, array, index, expected):
+    cds = mocker.Mock()
+    cds.data = {'pair_index': np.array(array)}
+    expected = np.array(expected)
+    result = figures._boolean_filter_indices_by_pair(cds, index)
+    assert np.all(result == expected)
+
+
+@pytest.mark.parametrize('fmin,fmax,omin,omax,expected', [
+    (-5, 5, -3, 3, (-5, 5)),
+    (1, 5, 0, 4, (0, 5)),
+    (np.nan, np.nan, np.nan, np.nan, (-999, 999)),
+])
+def test_get_scatter_limits(fmin, fmax, omin, omax, expected):
+    cds = ColumnDataSource({
+        'observation_values': np.array([omin, omax]),
+        'forecast_values': np.array([fmin, fmax]),
+    })
+    assert figures._get_scatter_limits(cds) == expected
+
+
+@pytest.mark.parametrize('y_min,y_max,pad,expected', [
+    (1.0, 10.0, 0.5, (0.0, 5.0)),
+    (-5.0, 10.0, 1.5, (-7.5, 15.0)),
+    (-5.0, -1.0, 1.0, (-5.0, 0.0)),
+    (-100.0, 100.0, 1.03, (-103.0, 103.0)),
+])
+def test_start_end(y_min, y_max, pad, expected):
+    result = figures.calc_y_start_end(y_min, y_max, pad)
+    assert result == expected
 
 
 @pytest.mark.parametrize('arg,expected', [
@@ -14,3 +211,39 @@ import pytest
 def test_abbreviate(arg, expected):
     out = figures.abbreviate(arg)
     assert out == expected
+
+
+def test_timeseries(report_with_raw):
+    timeseries_cds, metadata_cds = figures.construct_timeseries_cds(
+        report_with_raw)
+    fig = figures.timeseries(
+        timeseries_cds,
+        metadata_cds,
+        report_with_raw.start,
+        report_with_raw.end,
+        report_with_raw.forecast_observations[0].forecast.units
+    )
+    assert fig is not None
+
+
+def test_scatter(report_with_raw):
+    timeseries_cds, metadata_cds = figures.construct_timeseries_cds(
+        report_with_raw)
+    fig = figures.scatter(
+        timeseries_cds,
+        metadata_cds,
+        report_with_raw.forecast_observations[0].forecast.units,
+    )
+    assert fig is not None
+
+
+def test_timeseries_plots(report_with_raw):
+    script, div = figures.timeseries_plots(report_with_raw)
+    assert script is not None
+    assert div is not None
+
+
+def test_raw_report_plots(report_with_raw):
+    metrics = report_with_raw.raw_report.metrics
+    plots = figures.raw_report_plots(report_with_raw, metrics)
+    assert plots is not None

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -522,3 +522,20 @@ def test_forecast_sfp_aggregate_dict(single_forecast_text, aggregate):
     forecast_dict['aggregate'] = aggregate_dict
     forecast = datamodel.Forecast.from_dict(forecast_dict)
     assert isinstance(forecast.aggregate, datamodel.Aggregate)
+
+
+@pytest.mark.parametrize('key,value,expected', [
+    ('effective_until', None, None),
+    ('effective_until', '2020-01-01T00:00Z',
+     pd.Timestamp('2020-01-01T00:00Z')),
+    ('observation_deleted_at', None, None),
+    ('observation_deleted_at', '2020-01-01T00:00Z',
+     pd.Timestamp('2020-01-01T00:00Z'))
+])
+def test_aggregate_observation_sfp(
+        aggregate_observations, key, value, expected):
+    aggobs = aggregate_observations[0]
+    aggobs_dict = aggobs.to_dict()
+    aggobs_dict[key] = value
+    aggobs_from_dict = datamodel.AggregateObservation.from_dict(aggobs_dict)
+    assert getattr(aggobs_from_dict, key) == expected

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -185,9 +185,6 @@ def test_from_dict_into_datamodel_no_extra(pdid_params):
 
 def test_from_dict_no_extra(pdid_params):
     expected, obj_dict, model = pdid_params
-    if model == datamodel.BaseFilter:
-        pytest.skip('Skipping test of from_dict no extra, BaseFilter class '
-                    'contains no fields but may instantiate child classes.')
     names = [f.name for f in fields(model)]
     for key in list(obj_dict.keys()):
         if key not in names:

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -149,15 +149,16 @@ def basefilter_params(
         request, valuefilter, valuefilter_dict, quality_filter,
         quality_filter_dict, timeofdayfilter, timeofdayfilter_dict):
     parameters = [
-        (valuefilter, valuefilter_dict, datamodel.ValueFilter),
-        (quality_filter, quality_filter_dict, datamodel.QualityFlagFilter),
-        (timeofdayfilter, timeofdayfilter_dict, datamodel.TimeOfDayFilter)]
+        (valuefilter, valuefilter_dict),
+        (quality_filter, quality_filter_dict),
+        (timeofdayfilter, timeofdayfilter_dict)]
     return parameters[request.param]
 
 
 def test_base_filter_from_dict_into_datamodel(basefilter_params):
-    expected, obj_dict, model = basefilter_params
-    assert model.from_dict(obj_dict, raise_on_extra=True) == expected
+    expected, obj_dict = basefilter_params
+    out = datamodel.BaseFilter.from_dict(obj_dict, raise_on_extra=True)
+    assert out == expected
 
 
 def test_from_dict_into_datamodel_missing_field(pdid_params):

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -17,7 +17,9 @@ from solarforecastarbiter import datamodel
                         'probabilisticforecast', 'aggregate',
                         'aggregateforecast', 'aggregateprobforecast',
                         'report', 'quality_filter',
-                        'timeofdayfilter', 'valuefilter'])
+                        'timeofdayfilter', 'valuefilter', 'metricvalue',
+                        'metricresult', 'validationresult', 'reportmetadata',
+                        'reportfigure', 'reportmessage'])
 def pdid_params(request, many_sites, many_sites_text, single_observation,
                 single_observation_text, single_site,
                 single_forecast_text, single_forecast,
@@ -31,7 +33,11 @@ def pdid_params(request, many_sites, many_sites_text, single_observation,
                 agg_prob_forecast_constant_value,
                 report_objects, report_dict, quality_filter,
                 quality_filter_dict, timeofdayfilter,
-                timeofdayfilter_dict, valuefilter, valuefilter_dict):
+                timeofdayfilter_dict, valuefilter, valuefilter_dict,
+                metric_value_dict, metric_value, metric_result_dict,
+                metric_result, validation_result_dict, validation_result,
+                report_metadata_dict, report_metadata, report_figure_dict,
+                report_figure, report_message_dict, report_message):
     if request.param == 'site':
         return (many_sites[0], json.loads(many_sites_text)[0],
                 datamodel.Site)
@@ -105,6 +111,20 @@ def pdid_params(request, many_sites, many_sites_text, single_observation,
     elif request.param == 'valuefilter':
         return (valuefilter, valuefilter_dict,
                 datamodel.ValueFilter)
+    elif request.param == 'metricvalue':
+        return (metric_value, metric_value_dict, datamodel.MetricValue)
+    elif request.param == 'metricresult':
+        return (metric_result, metric_result_dict, datamodel.MetricResult)
+    elif request.param == 'validationresult':
+        return (validation_result, validation_result_dict,
+                datamodel.ValidationResult)
+    elif request.param == 'reportmetadata':
+        return (report_metadata, report_metadata_dict,
+                datamodel.ReportMetadata)
+    elif request.param == 'reportfigure':
+        return (report_figure, report_figure_dict, datamodel.ReportFigure)
+    elif request.param == 'reportmessage':
+        return (report_message, report_message_dict, datamodel.ReportMessage)
 
 
 @pytest.mark.parametrize('extra', [
@@ -396,3 +416,47 @@ def test___check_categories__():
     datamodel.__check_categories__(['total', 'weekday'])
     with pytest.raises(ValueError):
         datamodel.__check_categories__(['bad', 'very bad'])
+
+
+def test_aggregate_special_field_processing():
+    # :520-524
+    # TODO: test effective_until and observation_deleted at
+    pass
+
+
+def test_forecast_special_field_handling():
+    # :704
+    # TODO: test forecast datamodel loading when site or aggregate is a dict
+    pass
+
+
+def test_probabilistic_forecast__check_units__():
+    # :888
+    # TODO: test that value error is raised for different units for constants
+    pass
+
+
+def test_probabilistic_forecast_interval_compatibility():
+    # :893 897
+    # TODO: test that observation does not have greater interval length
+    #       also instant vs non-instant, should this exist for regular fx?
+    pass
+
+
+def test_base_filter_from_dict():
+    # :961
+    # TODO: generally test from dict, but with value range in the dict
+    #       This *may* just need to be added to another test.
+    pass
+
+
+def test_quality_flag_filter_post_init():
+    # 987
+    # TODO: test with invalid quality flag to raise valueerror
+    pass
+
+
+def test_metric_result_post_init():
+    # :1102
+    # TODO: test raising a valueerror when neither or both obs_id and agg_id
+    pass


### PR DESCRIPTION
Adds test coverage for `reports.figures.py` and some updates to the report fixtures. I didn't try to cover all of the Bokeh code and just called the plot-producing functions to ensure they complete with out errors.

All tests pass except for `test_apisession_get_report_with_raw` in `/io/tests/test_api.py`. For some reason the api is returning pandas Timestamps with fixed offset timezones like so: `Timestamp('2019-04-01 00:00:00-0700', tz='pytz.FixedOffset(-420)')`. 